### PR TITLE
Osx-javaOracle8 compile on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: java
-jdk:
-  - oraclejdk8
+
 sudo: false
-os:
-  - linux
+
+matrix:
+  include:
+    - os: linux
+      jdk: oraclejdk8
+    - os: osx
+      osx_image: xcode8
+
 cache:
   directories:
     - $HOME/.m2
+
 env:
   global:
     - MAVEN_OPTS="-Xms4g -Xmx4g"


### PR DESCRIPTION
Found a workaround here 

https://github.com/travis-ci/travis-ci/issues/2316